### PR TITLE
Improve geohash precision

### DIFF
--- a/components/LocationSearch/index.tsx
+++ b/components/LocationSearch/index.tsx
@@ -104,7 +104,7 @@ function CommandSearch({ location, onSelect }: CommandSearchProps) {
     });
     if (!result[0]) return;
     const coordinates = getLatLng(result[0]);
-    const geohash = Geohash.encode(coordinates.lat, coordinates.lng, 6);
+    const geohash = Geohash.encode(coordinates.lat, coordinates.lng, 8);
     setOpen(false);
     return onSelect({
       name,


### PR DESCRIPTION
Change from 6 to 8 characters when geocoding lat/long for greater precision