### PR TITLE
Stop using `about`, `description`, `address` tags

### DIFF
--- a/app/(app)/event/[naddr]/_components/Header.tsx
+++ b/app/(app)/event/[naddr]/_components/Header.tsx
@@ -59,14 +59,7 @@ export default function Header({ event }: { event: NDKEvent }) {
   const endDate = getTagValues("end", tags)
     ? new Date(parseInt(getTagValues("end", tags) as string) * 1000)
     : null;
-  const getLocation = () => {
-    let temp = getTagAllValues("location", tags);
-    if (temp[0]) {
-      return temp;
-    }
-    return getTagAllValues("address", tags);
-  };
-  const location = getLocation();
+  const location = getTagAllValues("location", tags);
   const rawEvent = event.rawEvent();
   const priceInBTC = parseFloat(getTagValues("price", rawEvent.tags) ?? "0");
   const isMember =

--- a/app/(app)/event/[naddr]/page.tsx
+++ b/app/(app)/event/[naddr]/page.tsx
@@ -69,9 +69,7 @@ export default function EventPage({
   const { tags } = event;
   const eventTagId = event.tagId();
 
-  const location = getTagAllValues("location", tags)[0]
-    ? getTagAllValues("location", tags)
-    : getTagAllValues("address", tags);
+  const location = getTagAllValues("location", tags)
   const geohash = getTagValues("g", tags);
   const hosts = getTagsAllValues("p", tags)
     .filter(([pubkey, relay, role]) => role === "host")

--- a/app/(app)/explore/_components/CalendarCard.tsx
+++ b/app/(app)/explore/_components/CalendarCard.tsx
@@ -38,7 +38,7 @@ export default function CalendarCard({ calendar }: CalendarCardProps) {
   const image = getTagValues("image", tags);
   const banner =
     getTagValues("banner", tags) ?? profile?.image ?? profile?.banner ?? BANNER;
-  const description = content ?? getTagValues("about", tags);
+  const description = content ?? '';
   const calendarEvents = getTagsValues("a", tags);
   const calendarEventIdentifiers = calendarEvents
     .filter(Boolean)

--- a/components/Cards/CalendarEvent/LargeFeedCard.tsx
+++ b/components/Cards/CalendarEvent/LargeFeedCard.tsx
@@ -35,8 +35,7 @@ type LargeFeedCardProps = {
 export default function LargeFeedCard({ event }: LargeFeedCardProps) {
   const { tags, pubkey, content } = event;
   const image = getTagValues("image", tags);
-  const location =
-    getTagValues("location", tags) ?? getTagValues("address", tags);
+  const location = getTagValues("location", tags);
   const users = getTagsValues("p", tags).filter(Boolean);
   const startDate = getTagValues("start", tags)
     ? new Date(parseInt(getTagValues("start", tags) as string) * 1000)

--- a/components/Cards/CalendarEvent/index.tsx
+++ b/components/Cards/CalendarEvent/index.tsx
@@ -11,6 +11,7 @@ import { NostrEvent } from "@nostr-dev-kit/ndk";
 import {
   getTagAllValues,
   getTagValues,
+  getTagsAllValues,
   getTagsValues,
 } from "@/lib/nostr/utils";
 import useProfile from "@/lib/hooks/useProfile";
@@ -31,7 +32,6 @@ export default function CalendarEventCard({
   const title = getTagValues("name", tags) || "Untitled";
   const image =
     getTagValues("image", tags) ??
-    getTagValues("picture", tags) ??
     getTagValues("banner", tags) ??
     profile?.banner;
 
@@ -42,14 +42,7 @@ export default function CalendarEventCard({
   const endDate = getTagValues("end", tags)
     ? new Date(parseInt(getTagValues("end", tags) as string) * 1000)
     : null;
-  const getLocation = () => {
-    let temp = getTagAllValues("location", tags);
-    if (temp[0]) {
-      return temp;
-    }
-    return getTagAllValues("address", tags);
-  };
-  const location = getLocation();
+  const location = getTagsAllValues("location", tags);
 
   const users = getTagsValues("p", tags);
   const hashtags = getTagsValues("t", tags);

--- a/components/Modals/CreateCalendar.tsx
+++ b/components/Modals/CreateCalendar.tsx
@@ -67,7 +67,6 @@ export default function CreateCalendarEventModal() {
       const tags: string[][] = [
         ["d", random],
         ["name", name],
-        ["description", description],
         ["p", currentUser.pubkey, "", "host"],
       ];
 

--- a/components/Modals/CreateCalendarEvent.tsx
+++ b/components/Modals/CreateCalendarEvent.tsx
@@ -121,7 +121,6 @@ export default function CreateCalendarEventModal({
       const tags: string[][] = [
         ["d", random],
         ["name", title],
-        ["description", description],
         ["start", toUnix(convertToTimezone(startDate, timezone)).toString()],
         ["end", toUnix(convertToTimezone(endDate, timezone)).toString()],
         ["start_tzid", timezone],
@@ -131,12 +130,6 @@ export default function CreateCalendarEventModal({
       if (location) {
         tags.push([
           "location",
-          `${location.name}, ${location.address}`,
-          location.name,
-          location.address,
-        ]);
-        tags.push([
-          "address",
           `${location.name}, ${location.address}`,
           location.name,
           location.address,

--- a/components/SubscriptionCard/index.tsx
+++ b/components/SubscriptionCard/index.tsx
@@ -38,10 +38,8 @@ export default function SubscriptionCard({ event }: { event: NDKEvent }) {
   const { tags } = event;
   const rawEvent = event.rawEvent();
   const title = getTagValues("title", tags) ?? getTagValues("name", tags) ?? "";
-  const image =
-    getTagValues("image", tags) ?? getTagValues("picture", tags) ?? BANNER;
-  const description =
-    getTagValues("description", tags) ?? getTagValues("summary", tags) ?? "";
+  const image = getTagValues("image", tags) ?? BANNER;
+  const description = getTagValues("description", tags) ?? getTagValues("summary", tags) ?? "";
   const delegate = getTagValues("delegate", tags);
   const priceInBTC = parseFloat(getTagValues("price", rawEvent.tags) ?? "0");
 

--- a/components/SubscriptionCard/index.tsx
+++ b/components/SubscriptionCard/index.tsx
@@ -39,7 +39,7 @@ export default function SubscriptionCard({ event }: { event: NDKEvent }) {
   const rawEvent = event.rawEvent();
   const title = getTagValues("title", tags) ?? getTagValues("name", tags) ?? "";
   const image = getTagValues("image", tags) ?? BANNER;
-  const description = getTagValues("description", tags) ?? getTagValues("summary", tags) ?? "";
+  const description =  event.content ?? "";
   const delegate = getTagValues("delegate", tags);
   const priceInBTC = parseFloat(getTagValues("price", rawEvent.tags) ?? "0");
 


### PR DESCRIPTION
It's better to just have the same information in a canonical place, saving everybody the hurdle of transmitting the repeated data over and over, and then checking all possible locations.

Since Flockstr is the only client doing these events for now as far as I know, whatever it does will be the actual standard, so if Flockstr checks for "description" data in 3 different places the standard becomes "description can be in any of these places" -- then in the future other apps will each put the description in one of these places, which forces all apps to check all places, but _just to be sure_ apps will opt to publish the data in _all_ of these places forever, which means events will be unnecessarily big forever.

The same applies to "address" and "location".

I am not sure my changes here are fully correct, but I can improve them if you agree with the changes.

Also I recommend following the same approach for other events that Flockstr is generating, the subscription stuff, for example. But I didn't change these since I don't know what is the preferred way. I suggest that you pick one standard and be strict about it. Thank you!